### PR TITLE
TouchStickType::Dynamic / Ui node interaction area & freinds 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ bevy = { version = "0.12", default-features = false, features = [
     "wayland",
     "webgl2"
 ] }
-# bevy-inspector-egui = "0.20"
+bevy-inspector-egui = {version = "0.21.0", default-features = false}
 leafwing-input-manager = "0.11"
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Only two-axis sticks are supported.
 ## Goals
 
 - [x] Support mouse and touch
-- [ ] Multiple joysticks on screen (for e.g. twin stick)
+- [x] Multiple joysticks on screen (For e.g. twin stick. Currently needs seperate instances of plugin)
 - [x] Emulate a regular bevy gamepad
 - [x] Minimal dependencies (including features)
 - [ ] Simple stupid implementation

--- a/examples/leafwing.rs
+++ b/examples/leafwing.rs
@@ -48,17 +48,15 @@ fn setup(mut commands: Commands) {
 
     // only here soo the camera movement system makes sense
     // just an object
-    commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                color: Color::PINK,
-                custom_size: Some(Vec2::splat(50.)),
-                ..default()
-            },
-            transform: Transform::from_xyz(20.0, 60.0, 0.0),
+    commands.spawn((SpriteBundle {
+        sprite: Sprite {
+            color: Color::PINK,
+            custom_size: Some(Vec2::splat(50.)),
             ..default()
         },
-    ));
+        transform: Transform::from_xyz(20.0, 60.0, 0.0),
+        ..default()
+    },));
 
     commands.spawn((
         Player { max_speed: 50. },

--- a/examples/leafwing.rs
+++ b/examples/leafwing.rs
@@ -3,13 +3,18 @@ use bevy::prelude::*;
 use bevy_touch_stick::prelude::*;
 use leafwing_input_manager::prelude::*;
 
-/// Marker type for our touch stick
+/// Marker type for look stick
 #[derive(Default, Reflect, Hash, Clone, PartialEq, Eq)]
-struct MyStick;
+struct LookStick;
+
+/// Marker type for touch stick
+#[derive(Default, Reflect, Hash, Clone, PartialEq, Eq)]
+struct MoveStick;
 
 #[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
 enum Action {
     Move,
+    Look,
 }
 
 fn main() {
@@ -20,12 +25,13 @@ fn main() {
             // add an inspector for easily changing settings at runtime
             // WorldInspectorPlugin::default(),
             // add the plugin
-            TouchStickPlugin::<MyStick>::default(),
+            TouchStickPlugin::<LookStick>::default(),
+            TouchStickPlugin::<MoveStick>::default(),
             // add leafwing plugin
             InputManagerPlugin::<Action>::default(),
         ))
         .add_systems(Startup, setup)
-        .add_systems(Update, move_player)
+        .add_systems(Update, (move_player, move_camera))
         .run();
 }
 
@@ -40,6 +46,20 @@ fn setup(mut commands: Commands) {
         ..default()
     });
 
+    // only here soo the camera movement system makes sense
+    // just an object
+    commands.spawn((
+        SpriteBundle {
+            sprite: Sprite {
+                color: Color::PINK,
+                custom_size: Some(Vec2::splat(50.)),
+                ..default()
+            },
+            transform: Transform::from_xyz(20.0, 60.0, 0.0),
+            ..default()
+        },
+    ));
+
     commands.spawn((
         Player { max_speed: 50. },
         InputManagerBundle::<Action> {
@@ -48,6 +68,7 @@ fn setup(mut commands: Commands) {
             // Describes how to convert from player inputs into those actions
             input_map: InputMap::default()
                 .insert(DualAxis::left_stick(), Action::Move)
+                .insert(DualAxis::right_stick(), Action::Look)
                 .build(),
         },
         SpriteBundle {
@@ -60,20 +81,50 @@ fn setup(mut commands: Commands) {
         },
     ));
 
-    // spawn a touch stick
+    // spawn a move stick
     commands.spawn((
+        BackgroundColor(Color::BLUE),
         // map this stick as a left gamepad stick (through bevy_input)
         // leafwing will register this as a normal gamepad
         TouchStickGamepadMapping::LEFT_STICK,
         TouchStickUiBundle {
-            stick: TouchStick::<MyStick>::default(),
+            stick: TouchStick {
+                id: MoveStick,
+                stick_type: TouchStickType::Dynamic,
+                ..default()
+            },
             // configure the interactable area through bevy_ui
             style: Style {
                 width: Val::Px(150.),
                 height: Val::Px(150.),
                 position_type: PositionType::Absolute,
-                left: Val::Percent(50.),
-                bottom: Val::Percent(15.),
+                left: Val::Percent(15.),
+                bottom: Val::Percent(5.),
+                ..default()
+            },
+            ..default()
+        },
+    ));
+
+    // spawn a look stick
+    commands.spawn((
+        BackgroundColor(Color::BLUE),
+        // map this stick as a right gamepad stick (through bevy_input)
+        // leafwing will register this as a normal gamepad
+        TouchStickGamepadMapping::RIGHT_STICK,
+        TouchStickUiBundle {
+            stick: TouchStick {
+                id: LookStick,
+                stick_type: TouchStickType::Floating,
+                ..default()
+            },
+            // configure the interactable area through bevy_ui
+            style: Style {
+                width: Val::Px(150.),
+                height: Val::Px(150.),
+                position_type: PositionType::Absolute,
+                right: Val::Percent(15.),
+                bottom: Val::Percent(5.),
                 ..default()
             },
             ..default()
@@ -82,10 +133,10 @@ fn setup(mut commands: Commands) {
 }
 
 fn move_player(
-    mut players: Query<(&mut Transform, &ActionState<Action>, &Player)>,
+    mut player: Query<(&mut Transform, &ActionState<Action>, &Player)>,
     time: Res<Time>,
 ) {
-    let (mut player_transform, action_state, player) = players.single_mut();
+    let (mut player_transform, action_state, player) = player.single_mut();
 
     if action_state.pressed(Action::Move) {
         let axis_value = action_state.clamped_axis_pair(Action::Move).unwrap().xy();
@@ -94,5 +145,21 @@ fn move_player(
 
         let move_delta = axis_value * player.max_speed * time.delta_seconds();
         player_transform.translation += move_delta.extend(0.);
+    }
+}
+
+fn move_camera(
+    player: Query<&ActionState<Action>, With<Player>>,
+    mut camera: Query<&mut Transform, With<Camera2d>>,
+) {
+    let input = player.single();
+    let mut camera_transform = camera.single_mut();
+
+    if input.pressed(Action::Look) {
+        let axis_value = input
+            .clamped_axis_pair(Action::Look)
+            .unwrap_or_default()
+            .xy();
+        camera_transform.translation += axis_value.extend(0.0)
     }
 }

--- a/examples/multiple.rs
+++ b/examples/multiple.rs
@@ -107,5 +107,4 @@ fn move_camera(
     let axis_value = right_stick.single().value;
 
     camera_transform.translation += axis_value.extend(0.0) * time.delta_seconds()
-
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -46,8 +46,12 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // spawn a touch stick
     commands
-        .spawn(TouchStickUiBundle::<MyStick> {
-            stick_node: TouchStickUi { id: MyStick },
+        .spawn(TouchStickUiBundle {
+            stick: TouchStick {
+                id: MyStick,
+                stick_type: TouchStickType::Dynamic,
+                ..default()
+            },
             style: Style {
                 width: Val::Px(150.),
                 height: Val::Px(150.),
@@ -67,7 +71,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent.spawn((
                 TouchStickUiKnob,
                 ImageBundle {
-                    image: asset_server.load("knob.png").into(),
+                    image: asset_server.load("Knob.png").into(),
                     style: Style {
                         width: Val::Px(75.),
                         height: Val::Px(75.),
@@ -80,7 +84,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent.spawn((
                 TouchStickUiOutline,
                 ImageBundle {
-                    image: asset_server.load("outline.png").into(),
+                    image: asset_server.load("Outline.png").into(),
                     style: Style {
                         width: Val::Px(150.),
                         height: Val::Px(150.),

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -3,6 +3,11 @@ use bevy::prelude::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+/// how the touch stick is positioned onscreen
+///
+/// - `Fixed`: Static position onscreen
+/// - `Floating`: spawn at pressed point
+/// - `Dynamic`: follow point on drag
 #[derive(Reflect, Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TouchStickType {

--- a/src/gamepad.rs
+++ b/src/gamepad.rs
@@ -33,7 +33,8 @@ impl<S: StickIdType> Plugin for GamepadMappingPlugin<S> {
 }
 
 /// HACK: chosen at random, we're betting on no collisions with gilrs gamepads
-const TOUCH_GAMEPAD_ID: usize = 6101115544193436746;
+/// updated too work on 32bit platforms, NOT u32::MAX, a bit less.
+const TOUCH_GAMEPAD_ID: usize = 4264937294;
 
 const TOUCH_GAMEPAD: Gamepad = Gamepad {
     id: TOUCH_GAMEPAD_ID,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,9 +136,16 @@ impl<S: Hash + Sync + Send + Clone + Default + Reflect + FromReflect + TypePath 
 }
 
 /// uses `Transform` if `Node` has no `Parent`, else uses `GlobalTransform`
+#[allow(clippy::type_complexity)]
 fn map_input_zones_from_ui_nodes<S: StickIdType>(
     mut interaction_areas: Query<
-        (&mut TouchStick<S>, &GlobalTransform, &Transform, &Node, Option<&Parent>),
+        (
+            &mut TouchStick<S>,
+            &GlobalTransform,
+            &Transform,
+            &Node,
+            Option<&Parent>,
+        ),
         With<TouchStickInteractionArea>,
     >,
 ) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -159,6 +159,12 @@ fn get_base_pos<S: StickIdType>(
                 stick.drag_start.extend(0.)
             }
         }
-        TouchStickType::Dynamic => stick.base_position.extend(0.),
+        TouchStickType::Dynamic => {
+            if stick.drag_id.is_none() || stick.base_position == Vec2::ZERO {
+                global_transform.translation()
+            } else {
+                stick.base_position.extend(0.)
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #2

Some small issues that have been annoying me the last few days
I was trying to work on my UI, but this was distracting

Feel free to use bits of this or none.
Not too familiar with git/rust, so I'm not sure about quality.

I was thinking about making the crate just have two possible sticks and only use the game pad mapping system instead of manually doing events.
If you wanted to create a custom joystick it would still work, however you would have to manually query for and construct the joystick value. It would make the simplicity and ergonomics much less. Even more so if you don't want to use leafwing-input-manager.

Enable bevy-inspector-egui as it's updated
update examples too use multiple joysticks
update README to reflect multiple joystick change
documentation on some structs
fix compile on 32bit platforms
    the game pad module used a 64bit usize?, causes issues when compiling
fix node interaction area if parented
fix TouchStickType::Dynamic implementation