### PR TITLE
re-enable bevy-inspector-egui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ bevy = { version = "0.12", default-features = false, features = [
     "wayland",
     "webgl2"
 ] }
-bevy-inspector-egui = "0.21.0"
+bevy-inspector-egui = {version = "0.21.0", default-features = false}
 leafwing-input-manager = "0.11"
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ bevy = { version = "0.12", default-features = false, features = [
     "wayland",
     "webgl2"
 ] }
-# bevy-inspector-egui = "0.20"
+bevy-inspector-egui = "0.21.0"
 leafwing-input-manager = "0.11"
 
 [[example]]

--- a/examples/leafwing.rs
+++ b/examples/leafwing.rs
@@ -18,7 +18,7 @@ fn main() {
         .add_plugins((
             DefaultPlugins,
             // add an inspector for easily changing settings at runtime
-            // WorldInspectorPlugin::default(),
+            WorldInspectorPlugin::default(),
             // add the plugin
             TouchStickPlugin::<MyStick>::default(),
             // add leafwing plugin

--- a/examples/leafwing.rs
+++ b/examples/leafwing.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-// use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_touch_stick::prelude::*;
 use leafwing_input_manager::prelude::*;
 

--- a/examples/multiple.rs
+++ b/examples/multiple.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-// use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_touch_stick::prelude::*;
 
 // ID for joysticks
@@ -14,7 +14,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            // WorldInspectorPlugin::new(),
+            WorldInspectorPlugin::new(),
             TouchStickPlugin::<Stick>::default(),
         ))
         .add_systems(Startup, create_scene)

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-// use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_touch_stick::{prelude::*, TouchStickUiKnob, TouchStickUiOutline};
 
 /// Marker type for our touch stick
@@ -12,7 +12,7 @@ fn main() {
         .add_plugins((
             DefaultPlugins,
             // add an inspector for easily changing settings at runtime
-            // WorldInspectorPlugin::default(),
+            WorldInspectorPlugin::default(),
             // add the plugin
             TouchStickPlugin::<MyStick>::default(),
         ))


### PR DESCRIPTION
bevy-inspector-egui was updated to bevy-0.12.
We can re-enable it in examples and dev-dependencies.
also removed bevy-inspector-egui default features
    - default features includes bevy_pbr types, causing a warning at runtime