### PR TITLE
make TOUCH_GAMEPAD_ID fit in 32bit usize

### DIFF
--- a/src/gamepad.rs
+++ b/src/gamepad.rs
@@ -33,7 +33,8 @@ impl<S: StickIdType> Plugin for GamepadMappingPlugin<S> {
 }
 
 /// HACK: chosen at random, we're betting on no collisions with gilrs gamepads
-const TOUCH_GAMEPAD_ID: usize = 6101115544193436746;
+/// updated too work on 32bit platforms, NOT u32::MAX, a bit less.
+const TOUCH_GAMEPAD_ID: usize = 4264937294;
 
 const TOUCH_GAMEPAD: Gamepad = Gamepad {
     id: TOUCH_GAMEPAD_ID,


### PR DESCRIPTION
on 32bit platforms, usize::MAX == 4,294,967,295
old value would fail too build for some android devices/wasm