### PR TITLE
Document all public types

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -47,7 +47,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // spawn a touch stick
     commands
         .spawn(TouchStickUiBundle::<MyStick> {
-            stick_node: TouchStickUi { id: MyStick },
             style: Style {
                 width: Val::Px(150.),
                 height: Val::Px(150.),

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -3,13 +3,18 @@ use bevy::prelude::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+/// how the touch stick is positioned onscreen
+///
+/// - `Fixed`: Static position onscreen
+/// - `Floating`: spawn at pressed point
+/// - `Dynamic`: follow point on drag
 #[derive(Reflect, Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TouchStickType {
     /// Static position
     Fixed,
     #[default]
-    /// Spawn at point click
+    /// Spawn at pressed point
     Floating,
     /// Follow point on drag
     Dynamic,

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -3,11 +3,7 @@ use bevy::prelude::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// how the touch stick is positioned onscreen
-///
-/// - `Fixed`: Static position onscreen
-/// - `Floating`: spawn at pressed point
-/// - `Dynamic`: follow point on drag
+/// How the touch stick is positioned onscreen
 #[derive(Reflect, Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TouchStickType {

--- a/src/gamepad.rs
+++ b/src/gamepad.rs
@@ -33,7 +33,7 @@ impl<S: StickIdType> Plugin for GamepadMappingPlugin<S> {
 }
 
 /// HACK: chosen at random, we're betting on no collisions with gilrs gamepads
-/// needs to be below u32::MAX to work on 32bit platforms.
+/// needs to be below `u32::MAX` to work on 32bit platforms.
 const TOUCH_GAMEPAD_ID: usize = 3407632091;
 
 const TOUCH_GAMEPAD: Gamepad = Gamepad {

--- a/src/gamepad.rs
+++ b/src/gamepad.rs
@@ -10,6 +10,9 @@ use bevy::{
 
 use crate::{StickIdType, TouchStick};
 
+/// Plugin that makes [`TouchStick`]s pretend to be regular bevy gamepads
+///
+/// Add [`GamepadAxisMapping`] to a [`TouchStick`] to make it show up as a bevy gamepad.
 pub(crate) struct GamepadMappingPlugin<S: StickIdType> {
     _marker: PhantomData<S>,
 }
@@ -20,9 +23,6 @@ impl<S: StickIdType> Default for GamepadMappingPlugin<S> {
     }
 }
 
-/// Plugin that makes TouchSticks pretend to be regular bevy gamepads
-///
-/// Add [`GamepadAxisMapping`] to a [`TouchStick`] to make it show up as a bevy gamepad.
 impl<S: StickIdType> Plugin for GamepadMappingPlugin<S> {
     fn build(&self, app: &mut App) {
         app.add_systems(
@@ -33,7 +33,7 @@ impl<S: StickIdType> Plugin for GamepadMappingPlugin<S> {
 }
 
 /// HACK: chosen at random, we're betting on no collisions with gilrs gamepads
-/// updated too work on 32bit platforms, NOT u32::MAX, a bit less.
+/// updated too work on 32bit platforms, NOT `u32::MAX`, a bit less.
 const TOUCH_GAMEPAD_ID: usize = 4264937294;
 
 const TOUCH_GAMEPAD: Gamepad = Gamepad {
@@ -42,15 +42,15 @@ const TOUCH_GAMEPAD: Gamepad = Gamepad {
 
 /// Mapping of a [`TouchStick`] to bevy gamepad axes.
 ///
-/// Adding this component to a `TouchStick` will create an emulated gamepad through `bevy_input`.
+/// Adding this component to a [`TouchStick`] will create an emulated gamepad through `bevy_input`.
 #[derive(Component, Reflect, Clone, Copy, Debug, Eq, PartialEq)]
 pub struct TouchStickGamepadMapping(pub GamepadAxisType, pub GamepadAxisType);
 
 impl TouchStickGamepadMapping {
-    /// defines default left stick mapping
+    /// Defines default left stick mapping
     pub const LEFT_STICK: Self =
         TouchStickGamepadMapping(GamepadAxisType::LeftStickX, GamepadAxisType::LeftStickY);
-    /// defines default right stick mapping
+    /// Defines default right stick mapping
     pub const RIGHT_STICK: Self =
         TouchStickGamepadMapping(GamepadAxisType::RightStickX, GamepadAxisType::RightStickY);
 }

--- a/src/gamepad.rs
+++ b/src/gamepad.rs
@@ -40,7 +40,9 @@ const TOUCH_GAMEPAD: Gamepad = Gamepad {
     id: TOUCH_GAMEPAD_ID,
 };
 
-/// mapping of touchstick x/y values too gamepad axis x/y values
+/// Mapping of a [`TouchStick`] to bevy gamepad axes.
+///
+/// Adding this component to a `TouchStick` will create an emulated gamepad through `bevy_input`.
 #[derive(Component, Reflect, Clone, Copy, Debug, Eq, PartialEq)]
 pub struct TouchStickGamepadMapping(pub GamepadAxisType, pub GamepadAxisType);
 

--- a/src/gamepad.rs
+++ b/src/gamepad.rs
@@ -40,12 +40,15 @@ const TOUCH_GAMEPAD: Gamepad = Gamepad {
     id: TOUCH_GAMEPAD_ID,
 };
 
+/// mapping of touchstick x/y values too gamepad axis x/y values
 #[derive(Component, Reflect, Clone, Copy, Debug, Eq, PartialEq)]
 pub struct TouchStickGamepadMapping(pub GamepadAxisType, pub GamepadAxisType);
 
 impl TouchStickGamepadMapping {
+    /// defines default left stick mapping
     pub const LEFT_STICK: Self =
         TouchStickGamepadMapping(GamepadAxisType::LeftStickX, GamepadAxisType::LeftStickY);
+    /// defines default right stick mapping
     pub const RIGHT_STICK: Self =
         TouchStickGamepadMapping(GamepadAxisType::RightStickX, GamepadAxisType::RightStickY);
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -8,6 +8,7 @@ use bevy::{
 };
 
 #[derive(Event)]
+/// actual device input passed too `TouchSticks`
 pub(crate) enum DragEvent {
     Start { id: u64, position: Vec2 },
     Drag { id: u64, position: Vec2 },

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,5 @@
 use crate::{
-    StickIdType, TouchStick, TouchStickEvent, TouchStickEventType, TouchStickType, TouchStickUi,
+    StickIdType, TouchStick, TouchStickEvent, TouchStickEventType, TouchStickType,
 };
 use bevy::{
     input::{mouse::MouseButtonInput, touch::TouchPhase, ButtonState},
@@ -18,11 +18,11 @@ pub(crate) enum DragEvent {
 pub(crate) fn update_sticks_from_drag_events<S: StickIdType>(
     mut drag_events: EventReader<DragEvent>,
     mut stick_events: EventWriter<TouchStickEvent<S>>,
-    mut sticks: Query<(&TouchStickUi<S>, &mut TouchStick<S>)>,
+    mut sticks: Query<&mut TouchStick<S>>,
 ) {
     let input_events = drag_events.read().collect::<Vec<&DragEvent>>();
 
-    for (node, mut stick) in sticks.iter_mut() {
+    for mut stick in sticks.iter_mut()  {
         for event in &input_events {
             match event {
                 DragEvent::Start { id, position } => {
@@ -62,7 +62,7 @@ pub(crate) fn update_sticks_from_drag_events<S: StickIdType>(
                     stick.drag_position = Vec2::ZERO;
                     stick.value = Vec2::ZERO;
                     stick_events.send(TouchStickEvent {
-                        id: node.id.clone(),
+                        id: stick.id.clone(),
                         event: TouchStickEventType::Release,
                         value: Vec2::ZERO,
                     });
@@ -76,7 +76,7 @@ pub(crate) fn update_sticks_from_drag_events<S: StickIdType>(
             && stick.drag_id.is_some()
         {
             stick_events.send(TouchStickEvent {
-                id: node.id.clone(),
+                id: stick.id.clone(),
                 event: TouchStickEventType::Drag,
                 value: stick.value,
             });

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,6 +1,4 @@
-use crate::{
-    StickIdType, TouchStick, TouchStickEvent, TouchStickEventType, TouchStickType,
-};
+use crate::{StickIdType, TouchStick, TouchStickEvent, TouchStickEventType, TouchStickType};
 use bevy::{
     input::{mouse::MouseButtonInput, touch::TouchPhase, ButtonState},
     prelude::*,
@@ -22,7 +20,7 @@ pub(crate) fn update_sticks_from_drag_events<S: StickIdType>(
 ) {
     let input_events = drag_events.read().collect::<Vec<&DragEvent>>();
 
-    for mut stick in sticks.iter_mut()  {
+    for mut stick in &mut sticks {
         for event in &input_events {
             match event {
                 DragEvent::Start { id, position } => {

--- a/src/input.rs
+++ b/src/input.rs
@@ -8,7 +8,7 @@ use bevy::{
 };
 
 #[derive(Event)]
-/// actual device input passed too `TouchSticks`
+/// Actual device input passed too [`TouchStick`]
 pub(crate) enum DragEvent {
     Start { id: u64, position: Vec2 },
     Drag { id: u64, position: Vec2 },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,9 +54,7 @@ mod ui;
 pub mod prelude {
     #[cfg(feature = "gamepad_mapping")]
     pub use crate::TouchStickGamepadMapping;
-    pub use crate::{
-        TouchStick, TouchStickPlugin, TouchStickType, TouchStickUiBundle,
-    };
+    pub use crate::{TouchStick, TouchStickPlugin, TouchStickType, TouchStickUiBundle};
 }
 
 #[cfg(feature = "gamepad_mapping")]
@@ -66,10 +64,7 @@ pub use crate::gamepad::TouchStickGamepadMapping;
 
 pub use crate::{
     behavior::TouchStickType,
-    ui::{
-        TouchStickInteractionArea, TouchStickUiBundle, TouchStickUiKnob,
-        TouchStickUiOutline,
-    },
+    ui::{TouchStickInteractionArea, TouchStickUiBundle, TouchStickUiKnob, TouchStickUiOutline},
 };
 use crate::{
     input::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,28 +3,42 @@
 //! see the examples for more detailed usage
 //!
 //! ## Example
-//!```no_run
-// # use bevy::prelude::*;
-// use bevy_touch_stick::prelude::*
-//! commands.spawn((
-//!     BackgroundColor(Color::BLUE),
-//!     TouchStickUiBundle {
-//!         stick: TouchStick {
-//!             id: Stick::Right,
-//!             stick_type: TouchStickType::Dynamic,
-//!             ..default()
-//!         },
-//!         style: Style {
-//!             width: Val::Px(150.),
-//!             height: Val::Px(150.),
-//!             position_type: PositionType::Absolute,
-//!             right: Val::Px(35.),
-//!             bottom: Val::Percent(15.),
-//!             ..default()
-//!         },
-//!         ..default()
-//!     }
-//! ));
+//!```rust
+//! use bevy::prelude::*;
+//! use bevy_touch_stick::prelude::*;
+//!
+//!#[derive(Default, Reflect, Hash, Clone, PartialEq, Eq)]
+//! enum Stick {
+//!     #[default]
+//!     Left,
+//!     Right,
+//! }
+//!
+//! fn main () {
+//!     App::new().add_systems(Startup, spawn_joystick).run()
+//! }
+//!
+//!  fn spawn_joystick(mut commands: Commands) {
+//!     commands.spawn((
+//!          BackgroundColor(Color::BLUE),
+//!          TouchStickUiBundle {
+//!              stick: TouchStick {
+//!                  id: Stick::Right,
+//!                  stick_type: TouchStickType::Dynamic,
+//!                  ..default()
+//!              },
+//!              style: Style {
+//!                  width: Val::Px(150.),
+//!                  height: Val::Px(150.),
+//!                  position_type: PositionType::Absolute,
+//!                  right: Val::Px(35.),
+//!                  bottom: Val::Percent(15.),
+//!                  ..default()
+//!              },
+//!              ..default()
+//!          }
+//!      ));
+//! }
 //!```
 //!
 use bevy::{prelude::*, reflect::TypePath, ui::UiSystem};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ use crate::{
 #[derive(Component, Clone, Debug, Reflect)]
 #[reflect(Component, Default)]
 pub struct TouchStick<S: StickIdType> {
-    /// Enum used for identifying the `TouchStick`
+    /// type used for identifying this `TouchStick`
     pub id: S,
     /// what drag event sequence is currently affecting this `TouchStick`
     pub drag_id: Option<u64>,
@@ -163,7 +163,7 @@ impl<S: StickIdType> Plugin for TouchStickPlugin<S> {
     }
 }
 
-/// type definition for TouchStickType
+/// type definition for TouchStick identifier
 pub trait StickIdType:
     Hash + Sync + Send + Clone + Default + Reflect + FromReflect + TypePath + 'static
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub mod prelude {
     #[cfg(feature = "gamepad_mapping")]
     pub use crate::TouchStickGamepadMapping;
     pub use crate::{
-        TouchStick, TouchStickPlugin, TouchStickType, TouchStickUi, TouchStickUiBundle,
+        TouchStick, TouchStickPlugin, TouchStickType, TouchStickUiBundle,
     };
 }
 
@@ -67,7 +67,7 @@ pub use crate::gamepad::TouchStickGamepadMapping;
 pub use crate::{
     behavior::TouchStickType,
     ui::{
-        TouchStickInteractionArea, TouchStickUi, TouchStickUiBundle, TouchStickUiKnob,
+        TouchStickInteractionArea, TouchStickUiBundle, TouchStickUiKnob,
         TouchStickUiOutline,
     },
 };
@@ -151,7 +151,6 @@ impl<S> Default for TouchStickPlugin<S> {
 impl<S: StickIdType> Plugin for TouchStickPlugin<S> {
     fn build(&self, app: &mut bevy::prelude::App) {
         app.register_type::<TouchStickInteractionArea>()
-            .register_type::<TouchStickUi<S>>()
             .register_type::<TouchStick<S>>()
             .register_type::<TouchStickType>()
             .register_type::<TouchStickEventType>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 //!
 //! ## Example
 //!```no_run
+// # use bevy::prelude::*;
+// use bevy_touch_stick::prelude::*
 //! commands.spawn((
 //!     BackgroundColor(Color::BLUE),
 //!     TouchStickUiBundle {
@@ -67,7 +69,7 @@ use crate::{
 #[derive(Component, Clone, Debug, Reflect)]
 #[reflect(Component, Default)]
 pub struct TouchStick<S: StickIdType> {
-    /// type used for identifying this `TouchStick`
+    /// Type used for identifying this [`TouchStick`]
     pub id: S,
     /// what drag event sequence is currently affecting this `TouchStick`
     pub drag_id: Option<u64>,
@@ -75,7 +77,7 @@ pub struct TouchStick<S: StickIdType> {
     pub dead_zone: f32,
     /// last drag positon of touchstick. only applies too `TouchStickType::Dynamic`
     ///
-    /// Vec2::ZERO if node is released
+    /// `Vec2::ZERO` if node is released
     pub base_position: Vec2,
     /// The screen position where the drag was started
     pub drag_start: Vec2,
@@ -115,15 +117,13 @@ impl<S: StickIdType> From<S> for TouchStick<S> {
 }
 
 impl<S: StickIdType> TouchStick<S> {
-    /// creates a new `TouchStick` with `s` as `StickIdType`
+    /// creates a new `TouchStick` with the given id.
     pub fn new(id: S) -> Self {
         Self { id, ..default() }
     }
 }
 
 /// plugin holding `TouchStick` functionality
-///
-/// add 1 per `TouchStick` your trying too spawn
 pub struct TouchStickPlugin<S> {
     _marker: PhantomData<S>,
 }
@@ -212,7 +212,7 @@ pub struct TouchStickEvent<S: StickIdType> {
 }
 
 impl<S: StickIdType> TouchStickEvent<S> {
-    /// returns the stick id that sent the event
+    /// Returns the id for the stick that sent the event
     pub fn id(&self) -> S {
         self.id.clone()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ mod gamepad;
 mod input;
 mod ui;
 
-/// commonly used exports from this crate
+/// Commonly used exports from this crate
 pub mod prelude {
     #[cfg(feature = "gamepad_mapping")]
     pub use crate::TouchStickGamepadMapping;
@@ -65,17 +65,17 @@ use crate::{
     ui::TouchStickUiPlugin,
 };
 
-/// pure data, independent of bevy_ui
+/// Pure data, independent of `bevy_ui`
 #[derive(Component, Clone, Debug, Reflect)]
 #[reflect(Component, Default)]
 pub struct TouchStick<S: StickIdType> {
     /// Type used for identifying this [`TouchStick`]
     pub id: S,
-    /// what drag event sequence is currently affecting this `TouchStick`
+    /// What drag event sequence is currently affecting this [`TouchStick`]
     pub drag_id: Option<u64>,
-    /// values smaller than this will not send `TouchStickEvent`
+    /// Axes values less than `dead_zone` will not send [`TouchStickEvent`]s
     pub dead_zone: f32,
-    /// last drag positon of touchstick. only applies too `TouchStickType::Dynamic`
+    /// Last `drag_position` of [`TouchStick`] only applies too [`TouchStickType::Dynamic`]
     ///
     /// `Vec2::ZERO` if node is released
     pub base_position: Vec2,
@@ -87,7 +87,7 @@ pub struct TouchStick<S: StickIdType> {
     pub value: Vec2,
     /// In input space (y-down)
     pub interactable_zone: Rect,
-    /// Defines the positioning behavior of the `TouchStick`
+    /// Defines the positioning behavior of the [`TouchStick`]
     pub stick_type: TouchStickType,
 }
 
@@ -117,13 +117,13 @@ impl<S: StickIdType> From<S> for TouchStick<S> {
 }
 
 impl<S: StickIdType> TouchStick<S> {
-    /// creates a new `TouchStick` with the given id.
+    /// Creates a new [`TouchStick`] with the given id.
     pub fn new(id: S) -> Self {
         Self { id, ..default() }
     }
 }
 
-/// plugin holding `TouchStick` functionality
+/// Plugin holding [`TouchStick`] functionality
 pub struct TouchStickPlugin<S> {
     _marker: PhantomData<S>,
 }
@@ -163,7 +163,7 @@ impl<S: StickIdType> Plugin for TouchStickPlugin<S> {
     }
 }
 
-/// type definition for TouchStick identifier
+/// Type definition for [`TouchStick`] identifier
 pub trait StickIdType:
     Hash + Sync + Send + Clone + Default + Reflect + FromReflect + TypePath + 'static
 {
@@ -191,23 +191,26 @@ fn map_input_zones_from_ui_nodes<S: StickIdType>(
     }
 }
 
-/// what action the TouchStick is experiencing
+/// What action the [`TouchStick`] is experiencing
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Reflect)]
 #[reflect]
 pub enum TouchStickEventType {
-    /// `TouchStick` was activated
+    /// [`TouchStick`] was activated
     Press,
-    /// `TouchStick` was moved
+    /// [`TouchStick`] was moved
     Drag,
-    /// `TouchStick` was deactivated
+    /// [`TouchStick`] was deactivated
     Release,
 }
 
-/// event sent whenever the touchstick is interacted.
+/// Event sent whenever the [`TouchStick`] is interacted.
 #[derive(Event)]
 pub struct TouchStickEvent<S: StickIdType> {
+    /// Identification for joystick that sent this event
     id: S,
+    /// What interaction did this [`TouchStick`] experience
     event: TouchStickEventType,
+    /// [`TouchStick`]
     value: Vec2,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! see the examples for more detailed usage
 //!
 //! ## Example
-//!```
+//!```no_run
 //! commands.spawn((
 //!     BackgroundColor(Color::BLUE),
 //!     TouchStickUiBundle {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -49,7 +49,7 @@ pub struct TouchStickUiBundle<S: StickIdType> {
     pub view_visibility: ViewVisibility,
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
-    /// Cursor position relative too the [`TouchStick`] in normalized logical pixels
+    /// Cursor position relative to the [`TouchStick`] in normalized logical pixels
     pub cursor_pos: RelativeCursorPosition,
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,7 +4,7 @@ use bevy::{
     render::{Extract, RenderApp},
     ui::{ContentSize, ExtractedUiNodes, FocusPolicy, RelativeCursorPosition, RenderUiSystem},
 };
-use std::{hash::Hash, marker::PhantomData};
+use std::marker::PhantomData;
 
 /// Marker component for a `bevy_ui` Node area where sticks can be interacted with.
 #[derive(Component, Copy, Clone, Debug, Default, Reflect)]
@@ -27,8 +27,6 @@ pub struct TouchStickUiOutline;
 pub struct TouchStickUiBundle<S: StickIdType> {
     /// Data describing the [`TouchStick`] state
     pub stick: TouchStick<S>,
-    /// Marker component
-    pub stick_node: TouchStickUi<S>,
     /// Where this node will accept touch input
     pub interaction_area: TouchStickInteractionArea,
     /// Describes the size of the node
@@ -53,14 +51,6 @@ pub struct TouchStickUiBundle<S: StickIdType> {
     pub z_index: ZIndex,
     /// Cursor position relative too the [`TouchStick`] in normalized logical pixels
     pub cursor_pos: RelativeCursorPosition,
-}
-
-/// marker component containing `[StickIdType`]
-#[derive(Component, Clone, Debug, Default, Reflect)]
-#[reflect(Component, Default)]
-pub struct TouchStickUi<S: Hash + Sync + Send + Clone + Default + Reflect + FromReflect + 'static> {
-    /// Identifier for [`TouchStick`]
-    pub id: S,
 }
 
 pub(crate) struct TouchStickUiPlugin<S: StickIdType> {
@@ -93,7 +83,6 @@ pub(crate) fn patch_stick_node<S: StickIdType>(
         Query<(
             &Node,
             &GlobalTransform,
-            &TouchStickUi<S>,
             &TouchStick<S>,
             &ViewVisibility,
         )>,
@@ -102,7 +91,7 @@ pub(crate) fn patch_stick_node<S: StickIdType>(
     outline_ui_query: Extract<Query<(Entity, &Parent), With<TouchStickUiOutline>>>,
 ) {
     for (knob_entity, knob_parent) in &knob_ui_query {
-        if let Ok((uinode, global_transform, _stick_ui, stick, visibility)) =
+        if let Ok((uinode, global_transform, stick, visibility)) =
             uinode_query.get(**knob_parent)
         {
             if visibility.get() && uinode.size().x != 0. && uinode.size().y != 0. {
@@ -125,7 +114,7 @@ pub(crate) fn patch_stick_node<S: StickIdType>(
     }
 
     for (outline_entity, outline_parent) in &outline_ui_query {
-        if let Ok((uinode, global_transform, _stick_ui, stick, visibility)) =
+        if let Ok((uinode, global_transform, stick, visibility)) =
             uinode_query.get(**outline_parent)
         {
             if visibility.get() && uinode.size().x != 0. && uinode.size().y != 0. {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -65,9 +65,8 @@ impl<S: StickIdType> Default for TouchStickUiPlugin<S> {
 
 impl<S: StickIdType> Plugin for TouchStickUiPlugin<S> {
     fn build(&self, app: &mut App) {
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
         };
         render_app.add_systems(
             ExtractSchedule,
@@ -79,21 +78,12 @@ impl<S: StickIdType> Plugin for TouchStickUiPlugin<S> {
 #[allow(clippy::type_complexity)]
 pub(crate) fn patch_stick_node<S: StickIdType>(
     mut extracted_uinodes: ResMut<ExtractedUiNodes>,
-    uinode_query: Extract<
-        Query<(
-            &Node,
-            &GlobalTransform,
-            &TouchStick<S>,
-            &ViewVisibility,
-        )>,
-    >,
+    uinode_query: Extract<Query<(&Node, &GlobalTransform, &TouchStick<S>, &ViewVisibility)>>,
     knob_ui_query: Extract<Query<(Entity, &Parent), With<TouchStickUiKnob>>>,
     outline_ui_query: Extract<Query<(Entity, &Parent), With<TouchStickUiOutline>>>,
 ) {
     for (knob_entity, knob_parent) in &knob_ui_query {
-        if let Ok((uinode, global_transform, stick, visibility)) =
-            uinode_query.get(**knob_parent)
-        {
+        if let Ok((uinode, global_transform, stick, visibility)) = uinode_query.get(**knob_parent) {
             if visibility.get() && uinode.size().x != 0. && uinode.size().y != 0. {
                 let radius = uinode.size().x / 2.;
                 let axis_value = stick.value;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,7 +6,7 @@ use bevy::{
 };
 use std::{hash::Hash, marker::PhantomData};
 
-/// Marker component for a bevy_ui Node area where sticks can be interacted with.
+/// Marker component for a `bevy_ui` Node area where sticks can be interacted with.
 #[derive(Component, Copy, Clone, Debug, Default, Reflect)]
 #[reflect(Component, Default)]
 pub struct TouchStickInteractionArea;
@@ -25,11 +25,11 @@ pub struct TouchStickUiOutline;
 /// Touch stick ui bundle for easy spawning
 #[derive(Bundle, Debug, Default)]
 pub struct TouchStickUiBundle<S: StickIdType> {
-    /// data describing the `TouchStick` state
+    /// Data describing the [`TouchStick`] state
     pub stick: TouchStick<S>,
-    /// marker component
+    /// Marker component
     pub stick_node: TouchStickUi<S>,
-    /// where this node will accept touch input
+    /// Where this node will accept touch input
     pub interaction_area: TouchStickInteractionArea,
     /// Describes the size of the node
     pub node: Node,
@@ -51,15 +51,15 @@ pub struct TouchStickUiBundle<S: StickIdType> {
     pub view_visibility: ViewVisibility,
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
-    /// cursor position relative too the `TouchStick` in normalized logical pixels
+    /// Cursor position relative too the [`TouchStick`] in normalized logical pixels
     pub cursor_pos: RelativeCursorPosition,
 }
 
-/// marker component containing `TouchStickId`
+/// marker component containing `[StickIdType`]
 #[derive(Component, Clone, Debug, Default, Reflect)]
 #[reflect(Component, Default)]
 pub struct TouchStickUi<S: Hash + Sync + Send + Clone + Default + Reflect + FromReflect + 'static> {
-    /// Identifier for `TouchStick`
+    /// Identifier for [`TouchStick`]
     pub id: S,
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -22,10 +22,14 @@ pub struct TouchStickUiKnob;
 pub struct TouchStickUiOutline;
 
 // TODO: default returns a broken bundle, should remove or fix
+/// Touch stick ui bundle for easy spawning
 #[derive(Bundle, Debug, Default)]
 pub struct TouchStickUiBundle<S: StickIdType> {
+    /// data describing the `TouchStick` state
     pub stick: TouchStick<S>,
+    /// marker component
     pub stick_node: TouchStickUi<S>,
+    /// where this node will accept touch input
     pub interaction_area: TouchStickInteractionArea,
     /// Describes the size of the node
     pub node: Node,
@@ -47,14 +51,15 @@ pub struct TouchStickUiBundle<S: StickIdType> {
     pub view_visibility: ViewVisibility,
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
+    /// cursor position relative too the `TouchStick` in normalized logical pixels
     pub cursor_pos: RelativeCursorPosition,
 }
 
-/// bevy ui config for a stick
+/// marker component containing `TouchStickId`
 #[derive(Component, Clone, Debug, Default, Reflect)]
 #[reflect(Component, Default)]
 pub struct TouchStickUi<S: Hash + Sync + Send + Clone + Default + Reflect + FromReflect + 'static> {
-    /// Identifier of joystick
+    /// Identifier for `TouchStick`
     pub id: S,
 }
 


### PR DESCRIPTION
Kinda opinionated, I feel.
Also, a generic crate level README.

I'm a pretty big fan of these Clippy lints:
  “missing-docs”,
// less useful for plugins/libraries
// not enabled for this PR
  “clippy::missing_docs_in_private_items” 
  
  Not intended to be merged just yet, if at all. This is probably the one that's going to need the most refinement. 