### PR TITLE
Bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,10 @@ bevy = { version = "0.14", default-features = false, features = [
     "x11",
     "webgl2"
 ] }
-bevy-inspector-egui = { version = "0.25", default-features = false, features = [
+bevy-inspector-egui = { version = "0.27.0", default-features = false, features = [
     "bevy_render"
 ] }
-leafwing-input-manager = "0.14"
+leafwing-input-manager = "0.15.1"
 
 [[example]]
 name = "leafwing"

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -89,8 +89,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     // background_color: BackgroundColor(colors::ORANGE.into()),
                     image: knob_handle.into(),
                     style: Style {
-                        margin: UiRect::all(Val::Auto),
-                        position_type: PositionType::Absolute,
+                        // REQUIRED style attributes
+                        position_type: PositionType::Absolute, // knob must be positioned absolutely
+                        margin: UiRect::all(Val::Auto), // margin must be set too Val::Auto or the knob wont be centered correctly
                         width: Val::Px(knob_size),
                         height: Val::Px(knob_size),
                         ..default()
@@ -105,6 +106,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     // background_color: BackgroundColor(colors::PURPLE.into()),
                     image: outline_handle.into(),
                     style: Style {
+                        // REQUIRED style attributes
                         margin: UiRect::all(Val::Auto),
                         position_type: PositionType::Absolute,
                         width: Val::Px(radius),

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{color::palettes::css as colors, prelude::*};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_touch_stick::{prelude::*, TouchStickUiKnob, TouchStickUiOutline};
 
@@ -27,16 +27,20 @@ struct Player {
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle {
-        transform: Transform::from_xyz(0., 0., 5.0),
-        ..default()
-    });
+    commands.spawn((
+        Name::new("Camera"),
+        Camera2dBundle {
+            transform: Transform::from_xyz(0., 0., 5.0),
+            ..default()
+        },
+    ));
 
     commands.spawn((
+        Name::new("Player"),
         Player { max_speed: 50. },
         SpriteBundle {
             sprite: Sprite {
-                color: Color::ORANGE,
+                color: colors::ORANGE.into(),
                 custom_size: Some(Vec2::splat(50.)),
                 ..default()
             },
@@ -44,43 +48,67 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         },
     ));
 
+    // size of outline for touchstick
+    let radius = 250.0;
+    // knob size for touchstick
+    let knob_size = 75.0;
+    let knob_handle: Handle<Image> = asset_server.load("knob.png");
+    let outline_handle: Handle<Image> = asset_server.load("outline.png");
+    // define 2 position elements and then leave the other 2 at Val::Auto,
+    let position = UiRect { left: Val::Px(0.0), right: Val::Auto, top: Val::Auto, bottom: Val::Px(0.0) };
+
+    // TODO: extract below to reuseable function?
     // spawn a touch stick
     commands
-        .spawn(TouchStickUiBundle::<MyStick> {
-            stick: TouchStick::<MyStick> {
-                radius: 75.0,
+        .spawn((
+            Name::new("TouchStick"),
+            TouchStickUiBundle::<MyStick> {
+                stick: TouchStick::<MyStick> {
+                    stick_type: TouchStickType::Fixed,
+                    radius,
+                    ..default()
+                },
+                style: Style {
+                    width: Val::Px(radius),
+                    height: Val::Px(radius),
+                    top: position.top,
+                    bottom: position.bottom,
+                    left: position.left,
+                    right: position.right,
+                    position_type: PositionType::Absolute,
+                    ..default()
+                },
                 ..default()
             },
-            style: Style {
-                top: Val::Px(0.),
-                bottom: Val::Px(0.),
-                right: Val::Px(0.),
-                left: Val::Px(0.),
-                position_type: PositionType::Absolute,
-                ..default()
-            },
-            ..default()
-        })
+        ))
         .with_children(|parent| {
             parent.spawn((
+                Name::new("Knob"),
                 TouchStickUiKnob,
                 ImageBundle {
-                    image: asset_server.load("knob.png").into(),
+                    // background_color: BackgroundColor(colors::ORANGE.into()),
+                    image: knob_handle.into(),
                     style: Style {
-                        width: Val::Px(75.),
-                        height: Val::Px(75.),
+                        margin: UiRect::all(Val::Auto),
+                        position_type: PositionType::Absolute,
+                        width: Val::Px(knob_size),
+                        height: Val::Px(knob_size),
                         ..default()
                     },
                     ..default()
                 },
             ));
             parent.spawn((
+                Name::new("Outline"),
                 TouchStickUiOutline,
                 ImageBundle {
-                    image: asset_server.load("outline.png").into(),
+                    // background_color: BackgroundColor(colors::PURPLE.into()),
+                    image: outline_handle.into(),
                     style: Style {
-                        width: Val::Px(150.),
-                        height: Val::Px(150.),
+                        margin: UiRect::all(Val::Auto),
+                        position_type: PositionType::Absolute,
+                        width: Val::Px(radius),
+                        height: Val::Px(radius),
                         ..default()
                     },
                     ..default()

--- a/examples/leafwing.rs
+++ b/examples/leafwing.rs
@@ -120,10 +120,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 ImageBundle {
                     image: asset_server.load("knob.png").into(),
                     style: Style {
+                        // REQUIRED style attributes
                         width: Val::Px(75.),
                         height: Val::Px(75.),
-                        margin: UiRect::all(Val::Auto),
-                        position_type: PositionType::Absolute,
+                        position_type: PositionType::Absolute, // knob must be positioned absolutely
+                        margin: UiRect::all(Val::Auto), // margin must be set too Val::Auto or the knob wont be centered correctly
                         ..default()
                     },
                     ..default()
@@ -134,6 +135,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 ImageBundle {
                     image: asset_server.load("outline.png").into(),
                     style: Style {
+                        // REQUIRED style attributes
                         width: Val::Px(150.),
                         height: Val::Px(150.),
                         margin: UiRect::all(Val::Auto),
@@ -175,10 +177,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 ImageBundle {
                     image: asset_server.load("knob.png").into(),
                     style: Style {
+                        // REQUIRED style attributes
                         width: Val::Px(75.),
                         height: Val::Px(75.),
-                        position_type: PositionType::Absolute,
-                        margin: UiRect::all(Val::Auto),
+                        position_type: PositionType::Absolute, // knob must be positioned absolutely
+                        margin: UiRect::all(Val::Auto), // margin must be set too Val::Auto or the knob wont be centered correctly
                         ..default()
                     },
                     ..default()
@@ -187,6 +190,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent.spawn((
                 TouchStickUiOutline,
                 ImageBundle {
+                    // REQUIRED style attributes
                     image: asset_server.load("outline.png").into(),
                     style: Style {
                         width: Val::Px(150.),

--- a/examples/leafwing.rs
+++ b/examples/leafwing.rs
@@ -1,6 +1,6 @@
 use std::f32::consts::PI;
 
-use bevy::prelude::*;
+use bevy::{prelude::*, color::palettes::css as colors};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_touch_stick::{prelude::*, TouchStickUiKnob, TouchStickUiOutline};
 use leafwing_input_manager::prelude::*;
@@ -66,7 +66,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ..default()
                 },
                 sprite: Sprite {
-                    color: Color::ORANGE,
+                    color: colors::ORANGE.into(),
                     custom_size: Some(Vec2::new(30., 50.)),
                     ..default()
                 },
@@ -82,7 +82,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ..default()
                 },
                 sprite: Sprite {
-                    color: Color::ORANGE,
+                    color: colors::ORANGE.into(),
                     custom_size: Some(Vec2::splat(50. / f32::sqrt(2.))),
                     ..default()
                 },
@@ -99,7 +99,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             TouchStickUiBundle {
                 stick: TouchStick {
                     id: Stick::Left,
-                    stick_type: TouchStickType::Fixed,
+                    stick_type: TouchStickType::Dynamic,
                     ..default()
                 },
                 // configure the interactable area through bevy_ui
@@ -122,6 +122,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     style: Style {
                         width: Val::Px(75.),
                         height: Val::Px(75.),
+                        margin: UiRect::all(Val::Auto),
+                        position_type: PositionType::Absolute,
                         ..default()
                     },
                     ..default()
@@ -134,6 +136,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     style: Style {
                         width: Val::Px(150.),
                         height: Val::Px(150.),
+                        margin: UiRect::all(Val::Auto),
+                        position_type: PositionType::Absolute,
                         ..default()
                     },
                     ..default()
@@ -173,6 +177,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     style: Style {
                         width: Val::Px(75.),
                         height: Val::Px(75.),
+                        position_type: PositionType::Absolute,
+                        margin: UiRect::all(Val::Auto),
                         ..default()
                     },
                     ..default()
@@ -185,6 +191,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     style: Style {
                         width: Val::Px(150.),
                         height: Val::Px(150.),
+                        position_type: PositionType::Absolute,
+                        margin: UiRect::all(Val::Auto),
                         ..default()
                     },
                     ..default()

--- a/examples/multiple.rs
+++ b/examples/multiple.rs
@@ -108,8 +108,9 @@ fn create_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ImageBundle {
                             image: asset_server.load("knob.png").into(),
                             style: Style {
-                                position_type: PositionType::Absolute,
-                                margin: UiRect::all(Val::Auto),
+                                // REQUIRED style attributes
+                                position_type: PositionType::Absolute, // knob must be positioned absolutely
+                                margin: UiRect::all(Val::Auto), // margin must be set too Val::Auto or the knob wont be centered correctly
                                 width: Val::Px(75.),
                                 height: Val::Px(75.),
                                 ..default()
@@ -122,6 +123,7 @@ fn create_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ImageBundle {
                             image: asset_server.load("outline.png").into(),
                             style: Style {
+                                // REQUIRED style attributes
                                 position_type: PositionType::Absolute,
                                 margin: UiRect::all(Val::Auto),
                                 width: Val::Px(150.),
@@ -159,8 +161,9 @@ fn create_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ImageBundle {
                             image: asset_server.load("knob.png").into(),
                             style: Style {
-                                position_type: PositionType::Absolute,
-                                margin: UiRect::all(Val::Auto),
+                                // REQUIRED style attributes
+                                position_type: PositionType::Absolute, // knob must be positioned absolutely
+                                margin: UiRect::all(Val::Auto), // margin must be set too Val::Auto or the knob wont be centered correctly
                                 width: Val::Px(75.),
                                 height: Val::Px(75.),
                                 ..default()
@@ -173,6 +176,7 @@ fn create_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ImageBundle {
                             image: asset_server.load("outline.png").into(),
                             style: Style {
+                                // REQUIRED style attributes
                                 position_type: PositionType::Absolute,
                                 margin: UiRect::all(Val::Auto),
                                 width: Val::Px(150.),

--- a/examples/multiple.rs
+++ b/examples/multiple.rs
@@ -108,6 +108,8 @@ fn create_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ImageBundle {
                             image: asset_server.load("knob.png").into(),
                             style: Style {
+                                position_type: PositionType::Absolute,
+                                margin: UiRect::all(Val::Auto),
                                 width: Val::Px(75.),
                                 height: Val::Px(75.),
                                 ..default()
@@ -120,6 +122,8 @@ fn create_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ImageBundle {
                             image: asset_server.load("outline.png").into(),
                             style: Style {
+                                position_type: PositionType::Absolute,
+                                margin: UiRect::all(Val::Auto),
                                 width: Val::Px(150.),
                                 height: Val::Px(150.),
                                 ..default()
@@ -155,6 +159,8 @@ fn create_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ImageBundle {
                             image: asset_server.load("knob.png").into(),
                             style: Style {
+                                position_type: PositionType::Absolute,
+                                margin: UiRect::all(Val::Auto),
                                 width: Val::Px(75.),
                                 height: Val::Px(75.),
                                 ..default()
@@ -167,6 +173,8 @@ fn create_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ImageBundle {
                             image: asset_server.load("outline.png").into(),
                             style: Style {
+                                position_type: PositionType::Absolute,
+                                margin: UiRect::all(Val::Auto),
                                 width: Val::Px(150.),
                                 height: Val::Px(150.),
                                 ..default()

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -72,10 +72,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 ImageBundle {
                     image: asset_server.load("knob.png").into(),
                     style: Style {
+                        // REQUIRED style attributes
                         width: Val::Px(75.),
                         height: Val::Px(75.),
-                        margin: UiRect::all(Val::Auto),
-                        position_type: PositionType::Absolute,
+                        position_type: PositionType::Absolute, // knob must be positioned absolutely
+                        margin: UiRect::all(Val::Auto), // margin must be set too Val::Auto or the knob wont be centered correctly
                         ..default()
                     },
                     ..default()
@@ -86,6 +87,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 ImageBundle {
                     image: asset_server.load("outline.png").into(),
                     style: Style {
+                        // REQUIRED style attributes
                         width: Val::Px(150.),
                         height: Val::Px(150.),
                         margin: UiRect::all(Val::Auto),

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -74,6 +74,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     style: Style {
                         width: Val::Px(75.),
                         height: Val::Px(75.),
+                        margin: UiRect::all(Val::Auto),
+                        position_type: PositionType::Absolute,
                         ..default()
                     },
                     ..default()
@@ -86,6 +88,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     style: Style {
                         width: Val::Px(150.),
                         height: Val::Px(150.),
+                        margin: UiRect::all(Val::Auto),
+                        position_type: PositionType::Absolute,
                         ..default()
                     },
                     ..default()

--- a/src/input.rs
+++ b/src/input.rs
@@ -118,7 +118,10 @@ pub(crate) fn send_drag_events_from_mouse(
     mut drag_events: EventWriter<DragEvent>,
     primary_window: Query<&Window, With<PrimaryWindow>>,
 ) {
-    let primary_window = primary_window.single();
+    let Ok(primary_window) = primary_window.get_single() else {
+        return
+    };
+
     let position = primary_window.cursor_position();
 
     for mouse_event in mouse_events.read() {


### PR DESCRIPTION
no longer update visual transform in render stage
instead use bevy ui layout tools too position knob/outline

fix example touchstick styles so they render properly

not really sure if this is your intended direction for this crate, i was unable too figure out a solution for bevys ui extraction phase creating new entity ids in render world instead of reusing the nodes. changes in bevy broke other ui rendering so it seems intentional.